### PR TITLE
obfuscate author email without base64

### DIFF
--- a/bunny-mock.gemspec
+++ b/bunny-mock.gemspec
@@ -1,7 +1,6 @@
 #!/usr/bin/env gem build
 # encoding: utf-8
 
-require 'base64'
 require File.expand_path("../lib/bunny_mock/version", __FILE__)
 
 Gem::Specification.new do |s|
@@ -9,7 +8,7 @@ Gem::Specification.new do |s|
   s.version     = BunnyMock::VERSION.dup
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Andrew Rempe']
-  s.email       = [Base64.decode64('YW5kcmV3cmVtcGVAZ21haWwuY29t\n')]
+  s.email       = ["616e6472657772656d706540676d61696c2e636f6d"].pack("H*")]
   s.summary     = 'Mocking for the popular Bunny client for RabbitMQ'
   s.description = 'Easy to use mocking for testing the Bunny client for RabbitMQ'
   s.license     = 'MIT'


### PR DESCRIPTION
The previous obfuscation for the author's email address used base64 which is no longer in the ruby stdlib as of 3.4. This change uses another method to achieve the same thing.